### PR TITLE
Fix dark mode paper texture rendering on iOS

### DIFF
--- a/style/tailwind.css
+++ b/style/tailwind.css
@@ -28,6 +28,14 @@
     background-blend-mode: multiply, normal, screen, normal;
 }
 
+@media (prefers-color-scheme: dark) {
+    .paper-texture {
+        background-image:
+            url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:svgjs="http://svgjs.dev/svgjs" viewBox="0 0 700 700" width="700" height="700" opacity="1"><defs><filter id="nnnoise-filter" x="-20%" y="-20%" width="140%" height="140%" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="linearRGB"><feTurbulence type="fractalNoise" baseFrequency="0.05" numOctaves="4" seed="15" stitchTiles="stitch" x="0%" y="0%" width="100%" height="100%" result="turbulence"></feTurbulence><feSpecularLighting surfaceScale="16" specularConstant="3" specularExponent="20" lighting-color="%23d6ae3d" x="0%" y="0%" width="100%" height="100%" in="turbulence" result="specularLighting"><feDistantLight azimuth="3" elevation="117"></feDistantLight></feSpecularLighting><feColorMatrix type="saturate" values="0" x="0%" y="0%" width="100%" height="100%" in="specularLighting" result="colormatrix"></feColorMatrix></filter></defs><rect width="700" height="700" fill="%231e293bff"></rect><rect width="700" height="700" fill="%23334155" filter="url(%23nnnoise-filter)"></rect></svg>');
+        background-blend-mode: normal;
+    }
+}
+
 .theme {
     background-color: var(--bg-color);
     color: var(--font-color);


### PR DESCRIPTION
The paper texture SVG was light-colored (cream/golden), so in dark mode the
text color dark: variants applied correctly but the background remained light,
causing unreadable light-on-light contrast. Add a @media (prefers-color-scheme:
dark) override that swaps in a dark slate-800 version of the SVG and uses
normal blend mode instead of multiply.

https://claude.ai/code/session_01VV7S7rN24zBYREGNt7athe